### PR TITLE
Add meson build support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,25 @@
+project('FFTSpectrum', 'c',
+  default_options : ['buildtype=release', 'b_ndebug=if-release', 'c_std=c99'],
+  meson_version : '>=0.49.0',
+  version : '2'
+)
+
+sources = 'FFTSpectrum.c'
+
+compiler = meson.get_compiler('c')
+
+if compiler.get_argument_syntax() == 'msvc'
+  deps = [ dependency('fftwf') ]
+  install_dir = 'installed'  # dummy
+else
+  vapoursynth_dep = dependency('vapoursynth').partial_dependency(compile_args : true, includes : true)
+  deps = [ dependency('fftw3f'), vapoursynth_dep ]
+  install_dir = join_paths(vapoursynth_dep.get_pkgconfig_variable('libdir'), 'vapoursynth')
+endif
+
+shared_module('fftspectrum', sources,
+  dependencies : deps,
+  install : true,
+  install_dir : install_dir,
+  gnu_symbol_visibility : 'hidden'
+)


### PR DESCRIPTION
It should work out of the box for Unix.

For windows, you will need to use vcpkg (to install fftw3) and pkgconfig-lite.
(please see https://github.com/AmusementClub/FFTSpectrum/blob/mod/.github/workflows/build.yaml on how to build statically linked Windows binaries.)

If you're interested in the github actions as well, I'm happy to also send a PR for that (or include in this PR, if you prefer).
Please let me know.

Thanks.